### PR TITLE
Edited load_image() method to use OpenCV library for loading images

### DIFF
--- a/Image_Controller.py
+++ b/Image_Controller.py
@@ -60,7 +60,8 @@ class ImageController:
         image_path = self.view.open_image_file(start_path=image_dir)
         self.model.set_image_path(image_path)
         self.model.load_image(image_path)
-        image = self.model.get_image()
+        # image = self.model.get_image()
+        image = self.model.get_tk_photoimage()
         self.view.display_image(image)
 
     def save_image(self):

--- a/Image_Model.py
+++ b/Image_Model.py
@@ -6,6 +6,7 @@
 # can update itself accordingly.
 
 import os
+import cv2  # OpenCV library
 from PIL import Image, ImageTk
 
 
@@ -103,7 +104,9 @@ class ImageModel:
         """
         # Load image logic
         print(f"ImageModel.load_image(): Loading image from: {image_path}")
-        self.image = ImageTk.PhotoImage(Image.open(self.image_path))
+        # self.image = ImageTk.PhotoImage(Image.open(self.image_path))
+        self.image = cv2.imread(image_path)
+        # print(f"ImageModel.load_image(): Loaded image: {self.image}")
 
     def get_image(self):
         """
@@ -112,8 +115,29 @@ class ImageModel:
         Returns
         ImageTk.PhotoImage: The loaded image object.
         """
-        print(f"ImageModel.get_photo(): Returning image: {self.image}")
+        print(f"ImageModel.get_image(): Returning image: {self.image}")
         return self.image
+
+    def get_tk_photoimage(self):
+        """
+        Gets the loaded image converted to a tkinter photoimage object.
+
+        This method converts the loaded image object to a tkinter photoimage
+        object, which is an image format used by tkinter for displaying
+        images.
+
+        Returns
+        ImageTk.PhotoImage: The loaded image object.
+        """
+        # OpenCV uses BGR format, PIL uses RGB
+        color_coverted = cv2.cvtColor(self.image, cv2.COLOR_BGR2RGB)
+        # Convert to PIL Image - from BGR to RGB format
+        pil_image = Image.fromarray(color_coverted)
+        print(f"ImageModel.get_tk_photoimage(): pil_image: {pil_image}")
+        # Convert to Tkinter PhotoImage object
+        tk_image = ImageTk.PhotoImage(image=pil_image)
+        print(f"ImageModel.get_tk_photoimage(): tk_image: {tk_image}")
+        return tk_image
 
     # Saves the edited image to the given path.
     def save_image(self, path):


### PR DESCRIPTION
Converted load_image() from Image_Model.py module so that it uses the OpenCV library.
OpenCV uses a different image encoding format that is not directly compatible with Tkinter libraries.
So OpenCV images need to be converted to be able to be displayed in Tkinter windows.
The get_cropped_image() method is now broken because it is using the PIL image format which is different to OpenCV as previously described. Yoana is working on this function to make crop work with OpenCV library image format.